### PR TITLE
feature: Added whiteListedTransportModes as a config option

### DIFF
--- a/MMM-Entur-tavle.js
+++ b/MMM-Entur-tavle.js
@@ -14,6 +14,7 @@ Module.register("MMM-Entur-tavle", {
         showTransportMode: false,
         timeOffset: [ 0, "seconds"],
         exclusions: [],
+        whiteListedTransportModes: [],
     },
 
     getStyles: function () {
@@ -43,6 +44,7 @@ Module.register("MMM-Entur-tavle", {
 
     getDepartures: function(){
         startTime = moment().add(moment.duration(this.config.timeOffset[0], this.config.timeOffset[1]));
+
         const payload = {
             url: this.config.ETApiUrl,
             ETClientName: this.config.ETClientName,
@@ -50,6 +52,7 @@ Module.register("MMM-Entur-tavle", {
             stopType: this.config.stopType,
             authorityId: this.config.authorityId,
             numResults: this.config.numResults,
+            whiteListedTransportModes: this.config.whiteListedTransportModes,
             startTime: startTime.toISOString(),
         };
         this.sendSocketNotification("GET_DEPARTURES", payload);

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Currently available configuration options are as follows:
 | showTransportMode | Boolean. Show the transporte mode as an icon. | false |
 | timeOffset | Array(int, string). How much into the future to offset a query.  For instance, setting `[10, "minutes"] will only give responses 10 minutes from "now". The array provided must be valid _array_ syntax for [moment.duration()](https://momentjs.com/docs/#/durations/). | [0, 'seconds']
 | exclusions | Array(string).  Public codes to exclude from display. For instance, `exclusions: [ 'a2', 'a4' ]` will exclude departures whose public code is 'a2' and 'a4'.  Note that this may mean that you get fewer results than those specified in the `numResults` config, so specifying this value may mean that you want to alter the numResults value until you get a satisfactory number of results. | []
+| whiteListedTransportModes | Array(string). If set will only display the given transport modes. For instance, `whiteListedTransportModes: [ 'tram', 'metro' ]` will only display trams and metros. Possible values are "bus", "rail", "metro", "pram", "coach".  numResults works as expected.   | []
 
 ## Finding stopPlace
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -25,11 +25,23 @@ module.exports = NodeHelper.create({
         } else if (data.stopType === "Quay"){
             queryInit = `quay (id: "${fullId}")`;
         };
+
+        let whitelist = data.whiteListedTransportModes;
+        if (whitelist.length !== 0){
+            whitelist = `[${whitelist}]`; // example format: whiteListedModes: [tram,metro]
+        } else {
+            whitelist = null;
+        }
+
         let $query =  `{
                 ${queryInit} {
                 id
                 name
-                estimatedCalls(${startTime} timeRange: 72100, numberOfDepartures: ${data.numResults}) {
+                estimatedCalls(${startTime}
+                    timeRange: 72100
+                    numberOfDepartures: ${data.numResults}
+                    whiteListedModes: ${whitelist}
+                    ) {
                   aimedDepartureTime
                   expectedDepartureTime
                   actualDepartureTime


### PR DESCRIPTION
Lets the user display only selected transport modes, e.g. metro. Useful when you have a station with multiple transport modes, but you are only interested in a subset.