### PR TITLE
make EN the fallback language

### DIFF
--- a/MMM-Entur-tavle.js
+++ b/MMM-Entur-tavle.js
@@ -26,9 +26,9 @@ Module.register("MMM-Entur-tavle", {
     },
     getTranslations: function() {
         return {
+            en: "translations/en.json",
             nb: "translations/nb.json",
-            nn: "translations/nn.json",
-            en: "translations/en.json"
+            nn: "translations/nn.json"
         };
     },
 


### PR DESCRIPTION
According to https://docs.magicmirror.builders/development/core-module-file.html#module-instance-methods if no there is no language match found, the first one in the list is returned. This PR changes the list to return `en` as the first element.